### PR TITLE
Workaround for C++ syntax inconsistencies

### DIFF
--- a/Seti.tmTheme
+++ b/Seti.tmTheme
@@ -4739,6 +4739,23 @@
                 <string>#EDBA00</string>
             </dict>
         </dict>
+
+        <!-- ====================================
+        C/C++
+        ====================================== -->
+        <!-- SublimeText C++-syntax are a bit inconsistent, correct that -->
+        <dict>
+            <key>name</key>
+            <string>C++ open bracket fix</string>
+            <key>scope</key>
+            <string>punctuation.definition.parameters.c,meta.function-call.c</string>
+            <key>settings</key>
+            <dict>
+                <key>foreground</key>
+                <string>#D8F6FF</string>
+            </dict>
+        </dict>
+
     </array>
 </dict>
 </plist>

--- a/Seti.tmTheme
+++ b/Seti.tmTheme
@@ -630,6 +630,17 @@
             </dict>
         </dict>
         <dict>
+            <key>name</key>
+            <string>Inner String</string>
+            <key>scope</key>
+            <string>string.quoted.double, string.quoted.single</string>
+            <key>settings</key>
+            <dict>
+                <key>foreground</key>
+                <string>#02AEFF</string>
+            </dict>
+        </dict>
+        <dict>
             <key>scope</key>
             <string>string.regexp</string>
             <key>settings</key>


### PR DESCRIPTION
The Pull Request fixes two problems:

* The inner characters of a string were not highlighted. 
  * Added a definition affecting strings of all languages. It seems to work (also tested with PHP) and to not override the special strings (like inline SQL etc.)
* The left parenthesis of a function-definition or function-call would be highlighted inconsistently.
  * This seems to be a problem in the syntax-file itself. I only added a definition for C/C++ to not affect any other language-highlighting.