### PR TITLE
Added python definitions from Neon.tmTheme

### DIFF
--- a/Seti.tmTheme
+++ b/Seti.tmTheme
@@ -2957,6 +2957,374 @@
             </dict>
 
             <!-- ====================================
+            Python 3 by Peter Varo
+            ====================================== -->
+
+            <!-- ====================================
+            Python Improved by MattDMo
+            ====================================== -->
+            <dict>
+                <key>name</key>
+                <string>Generator/comprehension keywords</string>
+                <key>scope</key>
+                <string>meta.expression.generator keyword.control.flow</string>
+                <key>settings</key>
+                <dict>
+                    <key>fontStyle</key>
+                    <string></string>
+                    <key>background</key>
+                    <string></string>
+                    <key>foreground</key>
+                    <string>#FFFF00</string>
+                </dict>
+            </dict>
+    <!--         <dict>
+                <key>name</key>
+                <string>Python string</string>
+                <key>scope</key>
+                <string>string.quoted.single.block.python, string.quoted.double.block.python</string>
+                <key>settings</key>
+                <dict>
+                    <key>fontStyle</key>
+                    <string></string>
+                    <key>background</key>
+                    <string></string>
+                    <key>foreground</key>
+                    <string>#FFDF02</string>
+                </dict>
+            </dict>
+     -->        <dict>
+                <key>name</key>
+                <string>Python docstring</string>
+                <key>scope</key>
+                <string>comment.block.documentation.python</string>
+                <key>settings</key>
+                <dict>
+                    <key>fontStyle</key>
+                    <string>italic</string>
+                    <key>foreground</key>
+                    <string>#218B97</string>
+                </dict>
+            </dict>
+            <dict>
+                <key>name</key>
+                <string>Docstring quotes</string>
+                <key>scope</key>
+                <string>punctuation.definition.comment.begin.python, punctuation.definition.comment.end.python</string>
+                <key>settings</key>
+                <dict>
+                    <key>fontStyle</key>
+                    <string>italic</string>
+                    <key>background</key>
+                    <string></string>
+                    <key>foreground</key>
+                    <string>#FF06A5</string>
+                </dict>
+            </dict>
+            <dict>
+                <key>name</key>
+                <string>=========== Python/PythonImproved ==========</string>
+                <key>scope</key>
+                <string></string>
+                <key>settings</key>
+                <dict>
+                    <key>fontStyle</key>
+                    <string></string>
+                    <key>background</key>
+                    <string></string>
+                    <key>foreground</key>
+                    <string></string>
+                </dict>
+            </dict>
+            <dict>
+                <key>name</key>
+                <string>Comprehension keywords</string>
+                <key>scope</key>
+                <string>meta.structure.list keyword.control.flow, meta.structure.list keyword.operator.logical, meta.structure.dictionary keyword.control.flow, meta.structure.dictionary keyword.operator.logical</string>
+                <key>settings</key>
+                <dict>
+                    <key>fontStyle</key>
+                    <string></string>
+                    <key>background</key>
+                    <string></string>
+                    <key>foreground</key>
+                    <string>#FFFF00</string>
+                </dict>
+            </dict>
+            <dict>
+                <key>name</key>
+                <string>PythonImproved docstring</string>
+                <key>scope</key>
+                <string>comment.block.python string.quoted.single.block.python, comment.block.python string.quoted.double.block.python</string>
+                <key>settings</key>
+                <dict>
+                    <key>fontStyle</key>
+                    <string>italic</string>
+                    <key>foreground</key>
+                    <string>#218B97</string>
+                </dict>
+            </dict>
+            <dict>
+                <key>name</key>
+                <string>Annotation separator :</string>
+                <key>scope</key>
+                <string>punctuation.separator.annotation.python</string>
+                <key>settings</key>
+                <dict>
+                    <key>background</key>
+                    <string>#0205FF</string>
+                    <key>fontStyle</key>
+                    <string>bold italic</string>
+                    <key>foreground</key>
+                    <string>#F6FF04</string>
+                </dict>
+            </dict>
+            <dict>
+                <key>name</key>
+                <string>Annotation result -&gt;</string>
+                <key>scope</key>
+                <string>punctuation.separator.annotation.result.python</string>
+                <key>settings</key>
+                <dict>
+                    <key>background</key>
+                    <string>#0205FF</string>
+                    <key>fontStyle</key>
+                    <string>bold italic</string>
+                    <key>foreground</key>
+                    <string>#F6FF04</string>
+                </dict>
+            </dict>
+            <dict>
+                <key>name</key>
+                <string>Annotation parameters group begin (</string>
+                <key>scope</key>
+                <string>punctuation.definition.parameters-group.begin.python</string>
+                <key>settings</key>
+                <dict>
+                    <key>fontStyle</key>
+                    <string>bold italic</string>
+                    <key>foreground</key>
+                    <string>#FF06A5</string>
+                </dict>
+            </dict>
+            <dict>
+                <key>name</key>
+                <string>Annotation parameters group end )</string>
+                <key>scope</key>
+                <string>punctuation.definition.parameters-group.end.python</string>
+                <key>settings</key>
+                <dict>
+                    <key>fontStyle</key>
+                    <string>bold italic</string>
+                    <key>foreground</key>
+                    <string>#FF06A5</string>
+                </dict>
+            </dict>
+            <dict>
+                <key>name</key>
+                <string>Comment - Note</string>
+                <key>scope</key>
+                <string>comment.line.note</string>
+                <key>settings</key>
+                <dict>
+                    <key>background</key>
+                    <string>#000B76</string>
+                    <key>foreground</key>
+                    <string>#E2FF09</string>
+                </dict>
+            </dict>
+            <dict>
+                <key>name</key>
+                <string>Comment - Note - Notation</string>
+                <key>scope</key>
+                <string>comment.line.note.notation</string>
+                <key>settings</key>
+                <dict>
+                    <key>fontStyle</key>
+                    <string>bold</string>
+                    <key>foreground</key>
+                    <string>#FF112C</string>
+                </dict>
+            </dict>
+            <dict>
+                <key>name</key>
+                <string>Decorator</string>
+                <key>scope</key>
+                <string>meta.function.decorator entity.name.function.decorator, meta.function.decorator support.type, punctuation.definition.decorator</string>
+                <key>settings</key>
+                <dict>
+                    <key>fontStyle</key>
+                    <string>bold</string>
+                    <key>foreground</key>
+                    <string>#B6B8FE</string>
+                </dict>
+            </dict>
+            <dict>
+                <key>name</key>
+                <string>Django models</string>
+                <key>scope</key>
+                <string>support.type.django.model</string>
+                <key>settings</key>
+                <dict>
+                    <key>foreground</key>
+                    <string>#588925</string>
+                </dict>
+            </dict>
+            <dict>
+                <key>name</key>
+                <string>Django modules</string>
+                <key>scope</key>
+                <string>support.other.django.module</string>
+                <key>settings</key>
+                <dict>
+                    <key>foreground</key>
+                    <string>#82C537</string>
+                </dict>
+            </dict>
+            <dict>
+                <key>name</key>
+                <string>Django keyword tag name</string>
+                <key>scope</key>
+                <string>keyword.control.tag-name.django</string>
+                <key>settings</key>
+                <dict>
+                    <key>fontStyle</key>
+                    <string>bold italic</string>
+                    <key>foreground</key>
+                    <string>#C2FFBD</string>
+                </dict>
+            </dict>
+            <dict>
+                <key>name</key>
+                <string>Django filter tag name</string>
+                <key>scope</key>
+                <string>keyword.control.filter.django</string>
+                <key>settings</key>
+                <dict>
+                    <key>background</key>
+                    <string>#908A0770</string>
+                    <key>fontStyle</key>
+                    <string></string>
+                    <key>foreground</key>
+                    <string>#0FD0FF</string>
+                </dict>
+            </dict>
+            <dict>
+                <key>name</key>
+                <string>Django template tag braces</string>
+                <key>scope</key>
+                <string>storage.type.templatetag.django entity.tag.tagbraces.django</string>
+                <key>settings</key>
+                <dict>
+                    <key>fontStyle</key>
+                    <string>bold italic</string>
+                    <key>foreground</key>
+                    <string>#1FA919</string>
+                </dict>
+            </dict>
+            <dict>
+                <key>name</key>
+                <string>Django variable tag braces</string>
+                <key>scope</key>
+                <string>storage.type.variable entity.tag.tagbraces.django</string>
+                <key>settings</key>
+                <dict>
+                    <key>fontStyle</key>
+                    <string>bold italic</string>
+                    <key>foreground</key>
+                    <string>#FF0D8F</string>
+                </dict>
+            </dict>
+            <dict>
+                <key>name</key>
+                <string>IPython In</string>
+                <key>scope</key>
+                <string>support.ipython.in</string>
+                <key>settings</key>
+                <dict>
+                    <key>foreground</key>
+                    <string>#17FF07</string>
+                </dict>
+            </dict>
+            <dict>
+                <key>name</key>
+                <string>IPython Out</string>
+                <key>scope</key>
+                <string>support.ipython.out</string>
+                <key>settings</key>
+                <dict>
+                    <key>foreground</key>
+                    <string>#FF0704</string>
+                </dict>
+            </dict>
+            <dict>
+                <key>name</key>
+                <string>IPython Cell Number</string>
+                <key>scope</key>
+                <string>source.python support.ipython support.ipython.cell-number</string>
+                <key>settings</key>
+                <dict>
+                    <key>fontStyle</key>
+                    <string>bold</string>
+                    <key>foreground</key>
+                    <string>#00B1F7</string>
+                </dict>
+            </dict>
+            <dict>
+                <key>name</key>
+                <string>Jinja filter</string>
+                <key>scope</key>
+                <string>variable.other.jinja.filter</string>
+                <key>settings</key>
+                <dict>
+                    <key>fontStyle</key>
+                    <string>bold italic</string>
+                    <key>foreground</key>
+                    <string>#10FDFF</string>
+                </dict>
+            </dict>
+            <dict>
+                <key>name</key>
+                <string>Jinja Variable</string>
+                <key>scope</key>
+                <string>variable.other.jinja</string>
+                <key>settings</key>
+                <dict>
+                    <key>foreground</key>
+                    <string>#FF0102</string>
+                </dict>
+            </dict>
+            <dict>
+                <key>name</key>
+                <string>Jinja tag delimiter</string>
+                <key>scope</key>
+                <string>entity.other.jinja.delimiter</string>
+                <key>settings</key>
+                <dict>
+                    <key>background</key>
+                    <string></string>
+                    <key>fontStyle</key>
+                    <string>bold</string>
+                    <key>foreground</key>
+                    <string>#FFF704</string>
+                </dict>
+            </dict>
+            <dict>
+                <key>name</key>
+                <string>Magic function</string>
+                <key>scope</key>
+                <string>support.function.magic</string>
+                <key>settings</key>
+                <dict>
+                    <key>fontStyle</key>
+                    <string>bold italic</string>
+                    <key>foreground</key>
+                    <string>#E3A0FF</string>
+                </dict>
+            </dict>
+
+
+            <!-- ====================================
             MagicPython - for Python 3.5+
             ====================================== -->
 


### PR DESCRIPTION
Neon.tmTheme is the color scheme belonging to the Python Improved language plugin.
I have inserted its python definitions into Seti.tmTheme.
A check for duplicate scopes I ran against the modified file did not find any *additional* duplications.

### This PR is for code review and collaboration.

#### TODO:
- adapt colors
  