### PR TITLE
Enhance the "block_caret" color in vim mode

### DIFF
--- a/Seti.tmTheme
+++ b/Seti.tmTheme
@@ -21,6 +21,8 @@
                     <string>#ffffff</string>
                     <key>caret</key>
                     <string>#ffd200</string>
+                    <key>block_caret</key>
+                    <string>#ffd200</string>
                     <key>invisibles</key>
                     <string>#ffd20050</string>
                     <key>lineHighlight</key>


### PR DESCRIPTION
Related issue:

* [Vim Vintage mode caret visibility issue](https://github.com/ctf0/Seti_ST3/issues/306)